### PR TITLE
Add PrestaShop Miravia connector module

### DIFF
--- a/prestashop/miraviaconnector/README.md
+++ b/prestashop/miraviaconnector/README.md
@@ -1,0 +1,13 @@
+# Miravia Connector for PrestaShop 9
+
+Este módulo proporciona una base para conectar PrestaShop 9 con la plataforma Miravia y sincronizar productos de forma bidireccional.
+
+## Instalación
+1. Copiar el directorio `miraviaconnector` dentro de la carpeta `modules` de su instalación de PrestaShop.
+2. Activar el módulo desde el panel de administración.
+
+## Uso
+- `exportProducts()` exporta productos de PrestaShop hacia Miravia.
+- `importProducts()` importa productos desde Miravia hacia PrestaShop.
+
+Se deben implementar las llamadas a la API de Miravia en la clase `MiraviaApi`.

--- a/prestashop/miraviaconnector/miraviaconnector.php
+++ b/prestashop/miraviaconnector/miraviaconnector.php
@@ -1,0 +1,47 @@
+<?php
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+class MiraviaConnector extends Module
+{
+    public function __construct()
+    {
+        $this->name = 'miraviaconnector';
+        $this->tab = 'administration';
+        $this->version = '1.0.0';
+        $this->author = 'InfinityCommerce';
+        $this->need_instance = 0;
+
+        parent::__construct();
+
+        $this->displayName = $this->l('Miravia Connector');
+        $this->description = $this->l('Bidirectional product sync between PrestaShop and Miravia.');
+    }
+
+    public function install()
+    {
+        return parent::install();
+    }
+
+    public function uninstall()
+    {
+        return parent::uninstall();
+    }
+
+    /**
+     * Export products from PrestaShop to Miravia.
+     */
+    public function exportProducts()
+    {
+        // TODO: Implement product export logic using MiraviaApi service
+    }
+
+    /**
+     * Import products from Miravia to PrestaShop.
+     */
+    public function importProducts()
+    {
+        // TODO: Implement product import logic using MiraviaApi service
+    }
+}

--- a/prestashop/miraviaconnector/src/MiraviaApi.php
+++ b/prestashop/miraviaconnector/src/MiraviaApi.php
@@ -1,0 +1,22 @@
+<?php
+class MiraviaApi
+{
+    private $endpoint;
+    private $token;
+
+    public function __construct($endpoint, $token)
+    {
+        $this->endpoint = rtrim($endpoint, '/');
+        $this->token = $token;
+    }
+
+    public function getProductList()
+    {
+        // TODO: Call Miravia API to fetch product list
+    }
+
+    public function pushProduct($productData)
+    {
+        // TODO: Send product data to Miravia via API
+    }
+}


### PR DESCRIPTION
## Summary
- add basic PrestaShop module skeleton for Miravia product sync

## Testing
- `php -v`
- `terraform version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68768650acf8832bafe6f4211a8a7d98